### PR TITLE
add compact option

### DIFF
--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -80,6 +80,7 @@ public function activityTimelineInfolist(Infolist $infolist): Infolist
                 ->showItemsIcon('heroicon-m-chevron-down') // Show button icon
                 ->showItemsColor('gray') // Show button color and it supports all colors
                 ->aside(true)
+                ->compact() // remove section card chrome when nested in another container
                 ->headingVisible(true) // make heading visible or not
                 ->extraAttributes(['class'=>'my-new-class']) // add extra class
         ]);

--- a/resources/views/components/empty-state.blade.php
+++ b/resources/views/components/empty-state.blade.php
@@ -1,10 +1,15 @@
 @props([
+    'compact' => false,
     'description' => null,
     'heading',
     'icon',
 ])
 
-<div {{ $attributes->class(['fi-timeline-empty-state px-6 py-12']) }}>
+<div {{ $attributes->class([
+    'fi-timeline-empty-state',
+    'px-6 py-12' => ! $compact,
+    'py-6' => $compact,
+]) }}>
     <div class="grid max-w-lg mx-auto text-center fi-timeline-empty-state-content justify-items-center">
         <div class="p-3 mb-4 bg-gray-100 rounded-full fi-timeline-empty-state-icon-ctn dark:bg-gray-500/20">
             <x-filament::icon :icon="$icon"

--- a/resources/views/components/section.blade.php
+++ b/resources/views/components/section.blade.php
@@ -1,39 +1,51 @@
-@props(['heading', 'headingVisible' => true, 'description' => null, 'aside' => true, 'extraAttributes' => []])
+@props([
+    'heading',
+    'headingVisible' => true,
+    'description' => null,
+    'aside' => true,
+    'compact' => false,
+    'extraAttributes' => [],
+])
 
 <section
     {{ $attributes->merge($extraAttributes, escape: false)->class([
             'fi-timeline-section',
-            'grid items-start grid-cols-1 gap-x-6 gap-y-4 md:grid-cols-3' => $aside && $headingVisible,
-            'bg-white shadow-sm rounded-xl ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10' => !$aside,
+            'fi-timeline-section-compact' => $compact,
+            'grid items-start grid-cols-1 gap-x-6 gap-y-4 md:grid-cols-3' => $aside && $headingVisible && ! $compact,
+            'bg-white shadow-sm rounded-xl ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10' => ! $aside && ! $compact,
         ]) }}>
 
     @if ($headingVisible)
         <header @class([
             'fi-timeline-section-header',
-            'flex flex-col gap-3 px-6 py-4 overflow-hidden sm:flex-row sm:items-center' => !$aside,
-            'flex flex-col gap-3 overflow-hidden sm:flex-row sm:items-center' => $aside,
+            'flex flex-col gap-3 overflow-hidden sm:flex-row sm:items-center' => $aside || $compact,
+            'flex flex-col gap-3 px-6 py-4 overflow-hidden sm:flex-row sm:items-center' => ! $aside && ! $compact,
+            'mb-4' => $compact,
         ])>
             <div class="grid flex-1 gap-y-1">
                 <h3
                     class="text-base font-semibold leading-6 fi-timeline-section-header-heading text-gray-950 dark:text-white">
                     {{ $heading }}
                 </h3>
-                <p class="text-sm text-gray-500 fi-timeline-section-header-description dark:text-gray-400">
-                    {{ $description }}
-                </p>
+                @if (filled($description))
+                    <p class="text-sm text-gray-500 fi-timeline-section-header-description dark:text-gray-400">
+                        {{ $description }}
+                    </p>
+                @endif
             </div>
         </header>
     @endif
 
-    @if ($aside)
+    @if ($aside && ! $compact)
         <div
             class="p-6 bg-white shadow-sm fi-timeline-section-content md:col-span-2 rounded-xl ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
             {{ $slot }}
         </div>
     @else
         <div @class([
-            'p-6 fi-timeline-section-content',
-            'border-t border-gray-200 dark:border-white/10' => $headingVisible,
+            'fi-timeline-section-content',
+            'p-6' => ! $compact,
+            'border-t border-gray-200 dark:border-white/10' => $headingVisible && ! $compact,
         ])>
             {{ $slot }}
         </div>

--- a/resources/views/infolists/components/activity-section.blade.php
+++ b/resources/views/infolists/components/activity-section.blade.php
@@ -1,4 +1,9 @@
-<x-activity-timeline::section :aside="$isAside()" :extraAttributes="$getExtraAttributes()" :headingVisible="$isHeadingVisible()">
+<x-activity-timeline::section
+    :aside="$isAside()"
+    :compact="$isCompact()"
+    :extraAttributes="$getExtraAttributes()"
+    :headingVisible="$isHeadingVisible()"
+>
     <x-slot name="heading">
         {{ $getLabel() ?? $getHeading() }}
     </x-slot>
@@ -87,6 +92,11 @@
 
         </div>
     @else
-        <x-activity-timeline::empty-state :description="$getEmptyStateDescription()" :heading="$getEmptyStateHeading()" :icon="$getEmptyStateIcon()" />
+        <x-activity-timeline::empty-state
+            :compact="$isCompact()"
+            :description="$getEmptyStateDescription()"
+            :heading="$getEmptyStateHeading()"
+            :icon="$getEmptyStateIcon()"
+        />
     @endif
 </x-activity-timeline::section>

--- a/src/Components/ActivitySection.php
+++ b/src/Components/ActivitySection.php
@@ -28,6 +28,8 @@ class ActivitySection extends Entry
 
     protected bool|Closure|null $isHeadingVisible = null;
 
+    protected bool|Closure $isCompact = false;
+
     public function description(string|Closure|null $description = null): static
     {
         $this->description = $description;
@@ -38,6 +40,13 @@ class ActivitySection extends Entry
     public function aside(bool|Closure|null $condition = true): static
     {
         $this->isAside = $condition;
+
+        return $this;
+    }
+
+    public function compact(bool|Closure $condition = true): static
+    {
+        $this->isCompact = $condition;
 
         return $this;
     }
@@ -80,6 +89,11 @@ class ActivitySection extends Entry
     public function isAside(): bool
     {
         return (bool) ($this->evaluate($this->isAside) ?? false);
+    }
+
+    public function isCompact(): bool
+    {
+        return (bool) $this->evaluate($this->isCompact);
     }
 
     public function getDescription(): ?string


### PR DESCRIPTION
## Summary

- Add `ActivitySection::compact()` for nesting timelines inside widgets/other sections without double chrome.
- In compact mode, drop section background, ring, shadow, and extra padding.
- Reduce empty-state padding and keep heading/description when compact.
- Document `->compact()` in the usage guide.

## Usage

```php
ActivitySection::make('activities')
    ->label('Incoming Events')
    ->compact()
    ->schema([
        // ...
    ]);